### PR TITLE
add link to ENCCS tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A curated list of awesome high performance computing resources.
 - [Memory bandwith NapkinMath](https://www.forrestthewoods.com/blog/memory-bandwidth-napkin-math/)
 - [Avoiding Instruction Cache Misses](https://paweldziepak.dev/2019/06/21/avoiding-icache-misses/)
 - [Multi-GPU Programming with Standard Parallel C++](https://developer.nvidia.com/blog/multi-gpu-programming-with-standard-parallel-c-part-1/)
+- [EuroCC National Competence Center Sweden (ENCCS) HPC tutorials](https://enccs.se/lessons/)
 
 #### Review Papers/Articles
 - [The Landscape of Exascale Research: A Data-Driven Literature Analysis (2020)](https://dl.acm.org/doi/pdf/10.1145/3372390)


### PR DESCRIPTION
ENCCS (EuroCC National Competence Centre Sweden) develops open source and public training materials on various topics in HPC, HPDA, AI and domain-specific topics. See https://enccs.se/lessons/