### PR TITLE
Added OKA to Cluster Management/Tools/Schedulers/Stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of awesome high performance computing resources.
 - [Lustre Parallel File System](https://www.lustre.org/) - A high-performance distributed filesystem for large-scale cluster computing.
 - [moosefs](https://moosefs.com/) - A fault-tolerant, highly available, distributed file system.
 - [NetApp](www.netapp.com) - Intelligent data infrastructure for various workloads.
+- [OKA](https://oka.how) - Analytics and reporting tool for HPC schedulers: helps administrators and users to understand how compute resources are used, and optimize their usage.
 - [Open Cluster Scheduler](https://github.com/hpc-gridware/clusterscheduler/) - A scalable HPC/AI workload manager based on SGE.
 - [OpenHPC](https://openhpc.community/) - A community-led set of HPC components.
 - [OpenOnDemand](https://openondemand.org/) - A web portal for accessing supercomputing resources.


### PR DESCRIPTION
Add OKA (https://oka.how/ & https://doc.oka.how/) to Cluster Management/Tools/Schedulers/Stacks section.

OKA is UCit's comprehensive HPC analytics and optimization platform that helps organizations monitor, predict, and optimize their computing infrastructure.

I'll be glad to give you a demo of OKA if you want to review its suitability with your list. 