### PR TITLE
 Add RunMat to General Purpose Scientific Computing Libraries for HPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A curated list of awesome high performance computing resources.
  - [rapids.ai - collection of libraries for executing end-to-end data science pipelines completely in the GPU](rapids.ai)
  - [trilinos](https://trilinos.github.io/)
  - [tnl project](https://tnl-project.org/)
+ - [RunMat](https://github.com/runmat-org/runmat) - MATLAB-syntax runtime with automatic CPU/GPU execution and fused array math kernels.
  
 #### Misc.
  - [mimalloc memory allocator](https://github.com/microsoft/mimalloc)


### PR DESCRIPTION
RunMat is an open-source MATLAB-syntax runtime for scientific and engineering workloads. It automatically uses CPU or GPU, fuses array math into kernels, and targets high-performance numerical workloads often run on HPC systems. Adding it under General Purpose Scientific Computing Libraries for HPC.

Repo: https://github.com/runmat-org/runmat