### PR TITLE
Add srunx to Development/Workflow/Monitoring Tools for HPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ A curated list of awesome high performance computing resources.
 - [Slurmvision slurm dashboard](https://github.com/Ruunyox/slurmvision) - A dashboard for monitoring and managing Slurm jobs.
 - [slurm docker cluster](https://github.com/giovtorres/slurm-docker-cluster) - A Slurm cluster implemented using Docker containers, for development and testing.
 - [snakemake](https://snakemake.readthedocs.io/en/stable/) - A workflow management system that reduces the complexity of creating reproducible and scalable data analyses.
+- [srunx](https://github.com/ksterx/srunx) - Python toolkit for managing SLURM jobs and workflows. Provides a CLI (sbatch / squeue / scancel parity), a FastAPI Web UI, an MCP server for natural-language control from Claude, YAML workflows with parameter sweeps and inter-job dependencies, GPU resource monitoring, SSH-based remote execution with rsync project sync, and Slack notifications.
 - [Stui slurm dashboard for the terminal](https://github.com/mil-ad/stui) - A terminal-based UI for managing and monitoring Slurm clusters.
 - [Vaex](https://github.com/vaexio/vaex) - A Python library for lazy Out-of-Core DataFrames (similar to Pandas), to visualize and explore big tabular datasets.
 


### PR DESCRIPTION
## What this PR adds

A new entry under **Development/Workflow/Monitoring Tools for HPC**:

> [srunx](https://github.com/ksterx/srunx) - Python toolkit for managing SLURM jobs and workflows. Provides a CLI (sbatch / squeue / scancel parity), a FastAPI Web UI, an MCP server for natural-language control from Claude, YAML workflows with parameter sweeps and inter-job dependencies, GPU resource monitoring, SSH-based remote execution with rsync project sync, and Slack notifications.

## Why this category

srunx sits alongside existing entries like snakemake, Stui, Slurmvision, HPC Rocket, and slop — workflow/dashboard/monitoring tools on top of SLURM. It is not a scheduler itself; it wraps SLURM with a higher-level CLI, a Web UI, and a YAML workflow engine.

## About the project

- License: Apache-2.0
- Python ≥3.12
- Installed via `pip install srunx` or `uvx srunx`
- Docs: https://ksterx.github.io/srunx/
- I'm the author.

## Placement

Inserted alphabetically between `snakemake` and `Stui slurm dashboard for the terminal`.