### PR TITLE
Add lazyslurm to Cluster Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ A curated list of awesome high performance computing resources.
 - [Globus Connect](https://www.globus.org/globus-connect) - A fast data transfer tool between supercomputers.
 - [Slurm Web](https://slurm-web.com/) - Open source web dashboard for Slurm HPC clusters.
 - [s9s](https://s9s.dev/) - TUI for SLURM cluster management
+- [lazyslurm](https://github.com/hill/lazyslurm) - A lazygit-style terminal UI for Slurm. Monitor jobs, tail logs, and inspect nodes and partitions.
   
 #### HPC-specific Operating Systems
 - [Kitten](https://www.sandia.gov/app/uploads/sites/210/2022/11/pedretti_lanl11.pdf) - A lightweight kernel designed for high-performance computing. It focuses on providing low noise and predictable performance for HPC applications.


### PR DESCRIPTION
Adds lazyslurm to Cluster Management/Tools/Schedulers/Stacks, alongside the existing Slurm tools (Slurm Web, s9s).

A lazygit-style terminal UI for Slurm, built with ratatui. It monitors jobs, tails logs, and shows node and partition state from a single binary. MIT licensed, published on crates.io.

![lazyslurm demo](https://github.com/hill/lazyslurm/raw/master/media/demo.gif)
